### PR TITLE
Dump a physical page when an untrusted call chain is encountered.

### DIFF
--- a/src/driver/stack_unwind.c
+++ b/src/driver/stack_unwind.c
@@ -460,6 +460,8 @@ GenericStackUnwind (
 		case STACK_UNWIND_UNTRUSTED_CALLCHAIN:
 			Dbg ("%s called by an untrusted call chain (RetEip=0x%08X).", 
 				FunctionName, LastRetEip);
+			// Handle this event the same way than an unknown module
+			UnknownModuleHandler (LastRetEip);
 		break;
 
 		case STACK_UNWIND_INVALID_SFP :


### PR DESCRIPTION
Currently, the untrusted call chains are detected but no particular action will be taken other than displaying a debug message.
Alternatively, it could be interesting to dump the caller page the same way than the unknowns modules for analyzing it later on.
