### PR TITLE
Add checks for ensuring that the image module has been found.

### DIFF
--- a/src/driver/module.c
+++ b/src/driver/module.c
@@ -235,7 +235,8 @@ AddressInModuleTableEntry (
 	IN DWORD Address,
 	IN PMODULE_ENTRY pModuleTableEntry
 ) {
-	return ((Address >=  (DWORD) pModuleTableEntry->BaseAddress)
+	return ((pModuleTableEntry != NULL)
+	    &&  (Address >=  (DWORD) pModuleTableEntry->BaseAddress)
 		&&  (Address <= ((DWORD) pModuleTableEntry->BaseAddress + pModuleTableEntry->SizeOfImage))
 	);
 }

--- a/src/driver/module.c
+++ b/src/driver/module.c
@@ -222,13 +222,12 @@ GetModuleTableEntry (
 //		Checks if the given address is in the given module
 //
 //	Parameters :
-//		IN DWORD Address										An address to check
-//		IN PMODULE_INFORMATION_TABLE ModuleInformationTable		A pointer to an allocated MODULE_INFORMATION_TABLE
+//		IN DWORD Address							An address to check
+//      IN PMODULE_ENTRY pModuleTableEntry          A pointer to an allocated MODULE_ENTRY
 //	Return value :
 //		PMODULE_ENTRY	A pointer to the PMODULE_ENTRY depending of the address given
 //							Returns NULL if the module hasn't been found.
 //	Process :
-//		Parse for each entry the base address and the size of the module
 //		Check if the given address is in bound of the module
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 BOOLEAN


### PR DESCRIPTION
Peb->ImageBaseAddress is not trustable enough for finding the image base address of the current process.

In case of the image module cannot be found, the driver crashes.
These commits add additionnals checks for ensuring that the image module has been found.
